### PR TITLE
Pre-commit hook to clear cell outputs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+# Run `pre-commit install` to activate pre-commit hooks
+repos:
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.7.1
+  hooks:
+    - id: nbstripout


### PR DESCRIPTION
- Add pre-commit config with nbstripout. This will reset cell output and execution_counts.

To activate pre-commit hooks, run `pre-commit install` in the repository root dir.