### PR TITLE
Install Utils instead of Kitchen

### DIFF
--- a/recipes/Components/Langchain_Embeddings_Models.ipynb
+++ b/recipes/Components/Langchain_Embeddings_Models.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen \\\n",
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    langchain-huggingface \\\n",
     "    langchain-ibm"
    ]

--- a/recipes/Components/Langchain_LLMs.ipynb
+++ b/recipes/Components/Langchain_LLMs.ipynb
@@ -24,7 +24,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen \\\n",
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    \"replicate\" \\\n",
+    "    \"langchain_ollama<0.2.0\" \\\n",
     "    \"langchain-ibm\""
    ]
   },

--- a/recipes/Components/Langchain_Vector_Stores.ipynb
+++ b/recipes/Components/Langchain_Vector_Stores.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen \\\n",
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    langchain-milvus \\\n",
     "    langchain-chroma"
    ]

--- a/recipes/Getting_Started/Getting_Started_with_Ollama.ipynb
+++ b/recipes/Getting_Started/Getting_Started_with_Ollama.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_ollama<0.2.0\""
    ]
   },
   {

--- a/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb
+++ b/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb
@@ -31,7 +31,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    \"replicate\""
    ]
   },
   {

--- a/recipes/Getting_Started/Getting_Started_with_WatsonX.ipynb
+++ b/recipes/Getting_Started/Getting_Started_with_WatsonX.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen \\\n",
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    \"langchain-ibm\""
    ]
   },


### PR DESCRIPTION
[pm #152](https://github.com/ibm-granite-community/pm/issues/152)
- Replace granite-kitchen with utils install in recipes.

### PR Checklist

- [ ] **Commits signed**: All commits must be GPG or SSH signed.
- [ ] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
- [ ] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [ ] **Automated testing**: Add the recipe to the automated tests.
- [ ] **Test in Google Colab**:
    - [ ] Test that it works in Google Colab (Python 3.10.12).
    - [ ] Colab has its own package set and Python version, so ensure compatibility.
- [ ] **Test locally**:
    - [ ] Ensure the code works in a fresh Python virtual environment (venv).
- [ ] **Flexible LLM platform support**:
    - [ ] The platform should be easily switchable. Use LangChain for now.
    - [ ] Include `!pip install git+https://github.com/ibm-granite-community/granite-kitchen` in the instructions.
- [ ] **Example data**: Follow the example data guidance.
- [ ] **README.md updates**:
    - [ ] Add a link to the recipe in the Table of Contents (ToC).
    - [ ] Include a Colab button after that link.
