### PR TITLE
fix ibm-granite-community-utils name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.0',
     packages=find_packages(),
     install_requires=[
-        "ibm-granite-community @ git+https://github.com/ibm-granite-community/utils",
+        "ibm-granite-community-utils @ git+https://github.com/ibm-granite-community/utils",
         "langchain_community<0.3.0",
         "langchain_ollama<0.2.0",
         "replicate",


### PR DESCRIPTION
In any of the notebooks, when 
```
! pip install "git+https://github.com/ibm-granite-community/granite-kitchen" 
```
is giving an error at the `utils` repo due the incorrect name:
```
Discarding git+https://github.com/ibm-granite-community/utils: Requested ibm-granite-community-utils from git+https://github.com/ibm-granite-community/utils (from granite-kitchen==0.1.0) has inconsistent name: expected 'ibm-granite-community', but metadata has 'ibm-granite-community-utils'
INFO: pip is looking at multiple versions of granite-kitchen to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement ibm-granite-community (unavailable) (from granite-kitchen) (from versions: none)
ERROR: No matching distribution found for ibm-granite-community (unavailable)
```

updating the package name to `ibm-granite-community-utils` fixes it!