### PR TITLE
Configure Dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     - ".github/actions/ollama-setup"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add cooldown period of 7 days for Dependabot updates.

