### PR TITLE
Update Replicate notebook terminology to use "Granite models"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For more background and a FAQ, please see the [community wiki](https://github.co
 
 ## Licenses
 
-The Granite Code Cookbook's base license is CC BY 4.0.
+The Granite Kitchen's base license is CC BY 4.0.
 
 Code in this repository, including in notebook cells, is licensed under Apache 2.0.
 

--- a/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb
+++ b/recipes/Getting_Started/Getting_Started_with_Replicate.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "### Add credit to your Replicate Account (optional)\n",
     "\n",
-    "To remove a barrier to entry to try the Granite Code models on the Replicate platform,\n",
+    "To remove a barrier to entry to try the Granite models on the Replicate platform,\n",
     "use [this link](https://replicate.fyi/ibm) to add a\n",
     "small amount of credit to your Replicate account."
    ]

--- a/recipes/Getting_Started_with_Jupyter_Locally/Getting_Started_with_Jupyter_Locally.md
+++ b/recipes/Getting_Started_with_Jupyter_Locally/Getting_Started_with_Jupyter_Locally.md
@@ -1,28 +1,28 @@
-# Running the Granite Code Recipe Notebooks Locally
+# Running the Granite Snack Recipe Notebooks Locally
 
-How to run the Granite Code recipe Jupyter notebooks on your computer.
+How to run the Granite Snack recipe Jupyter notebooks on your computer.
 
-## Clone the Granite Code Cookbook Repository
+## Clone the Granite Snack Cookbook Repository
 
 Clone the repo and cd into the repo directory.
 
 ```python
-git clone git@github.com:ibm-granite-cookbooks/granite-code-cookbook.git
+git clone git@github.com:ibm-granite-cookbooks/granite-snack-cookbook.git
 
-cd granite-code-cookbook
+cd granite-snack-cookbook
 ```
 
 ## Create and Activate a Virtual Environment
 
 Use a [python virtual environment](https://docs.python.org/3/library/venv.html) for installed libraries. Open a terminal, and from the command line, run:
 
-```python
+```shell
 python -m venv .venv
 ```
 
 Activate the virtual environment in the by running:
 
-```python
+```shell
 source ./.venv/bin/activate
 ```
 
@@ -32,7 +32,7 @@ For more detail, see the installation Instructions at [Jupyter.org](https://jupy
 
 Install jupyter notebook with pip in the virtual environment:
 
-```python
+```shell
 pip install notebook
 ```
 
@@ -42,10 +42,10 @@ To open a recipe notebook in jupyter, from the virtual environment, run:
 
 ```jupyter notebook <recipe-notebook-file-path>```
 
-To run the "Text to Shell" recipe from the repository root, for example:
+To run the "Document Summarization" recipe from the repository root, for example:
 
-```python
-jupyter notebook ./recipes/Text_to_Shell/Text_to_Shell.ipynb
+```shell
+jupyter notebook ./recipes/Summarize/Summarize.ipynb
 ```
 
 You should see the notebook in your browser now!
@@ -54,7 +54,7 @@ You should see the notebook in your browser now!
 
 [Jupyter Lab](https://jupyter.org/try-jupyter/lab/) provides a web-based notebook IDE, for interactive development of Jupyter notebooks.
 
-```python
+```shell
 pip install jupyterlab
 
 jupyter lab


### PR DESCRIPTION
# Summary

Updates terminology in the Getting Started with Replicate notebook to refer to "Granite models" instead of "Granite Code models" for broader applicability.

# Files Changed

📄 `recipes/Getting_Started/Getting_Started_with_Replicate.ipynb`

Simplified the model reference in the credit section by changing "Granite Code models" to "Granite models" to reflect a more general naming convention that encompasses the full family of Granite models available on the Replicate platform.