### PR TITLE
fix(docs): Update repository clone URL in Getting_Started_with_Jupyter_Locally.md

### DIFF
--- a/recipes/Getting_Started_with_Jupyter_Locally/Getting_Started_with_Jupyter_Locally.md
+++ b/recipes/Getting_Started_with_Jupyter_Locally/Getting_Started_with_Jupyter_Locally.md
@@ -6,9 +6,8 @@ How to run the Granite Snack recipe Jupyter notebooks on your computer.
 
 Clone the repo and cd into the repo directory.
 
-```python
-git clone git@github.com:ibm-granite-cookbooks/granite-snack-cookbook.git
-
+```shell
+git clone git@github.com:ibm-granite-community/granite-snack-cookbook.git
 cd granite-snack-cookbook
 ```
 


### PR DESCRIPTION
## Summary

Fixes #116

### Changes

- Corrected the org name in the `git clone` URL from `ibm-granite-cookbooks` (404) to `ibm-granite-community`
- Changed the code fence language tag from ```python to ```shell to match the rest of the file and properly reflect terminal commands